### PR TITLE
fix: half page up scroll

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,7 +8,8 @@ const scroll = (scroller: Scroller, direction: ScrollDirection, distance: Scroll
 	const editor = vscode.window.activeTextEditor!;
 	const ranges = editor.visibleRanges; // including potential folds
 	const visibleLines = calcVisibleLines(ranges);
-	let scrollDistance = distance === "halfPage" ? visibleLines / 2 : distance === "page" ? visibleLines : distance;
+	let scrollDistance =
+		distance === "halfPage" ? Math.floor(visibleLines / 2) : distance === "page" ? visibleLines : distance;
 
 	switch (true) {
 		// Scroll from top boundary


### PR DESCRIPTION
Thanks for the great extension.
There is a half-page up scrolling bug that was introduced in v0.2.0.
Half page up (Berthold up) scrolls one line more than necessary.

### Before the fix:
https://user-images.githubusercontent.com/16840190/222949200-a4749dc7-44d3-4c0a-bdc1-7501b2052a33.mp4

### After the fix:
https://user-images.githubusercontent.com/16840190/222949207-b8b2db04-60b1-4f57-8561-3a0006c50f40.mp4