### PR TITLE
fix: inconsistent default germanScroll.bertholdUp keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
 			},
 			{
 				"command": "germanScroll.bertholdUp",
-				"key": "ctrl+up",
-				"mac": "cmd+up",
+				"key": "ctrl+pageup",
+				"mac": "cmd+pageup",
 				"when": "editorTextFocus"
 			},
 			{


### PR DESCRIPTION
Inconsistent default germanScroll.bertholdUp keybinding conflicts with the default germanScroll.arminUp keybinding.